### PR TITLE
Bootstrap-spans are now reusable

### DIFF
--- a/portlets/lecture2go-portlet/docroot/guest/videosList.jsp
+++ b/portlets/lecture2go-portlet/docroot/guest/videosList.jsp
@@ -100,99 +100,100 @@
 	}
 		
 %>
-
-<div class="row-fluid">
-<%if(!resultSetEmpty){ %>
-	<div class="span3">
-		<liferay-ui:panel-container>
-			<!-- 	parentinstitution filter -->
-			<%if(presentParentInstitutions.size()>0){ %>
-			<liferay-ui:panel extended="true" title="institution" cssClass='${hasParentInstitutionFiltered ? "filtered" : "notFiltered"}'>
-				<ul>
-				<c:forEach items="<%=presentParentInstitutions %>" var="parentInstitution">
-					<portlet:actionURL var="filterByParentInstitution" name="addFilter">
-						<portlet:param name="jspPage" value="/guest/videosList.jsp" />
-						<portlet:param name="parentInstitutionId" value='${hasParentInstitutionFiltered ? "0" : parentInstitution.institutionId}'/>
-						<portlet:param name="institutionId" value="<%=institutionId.toString() %>"/>				
-						<portlet:param name="termId" value="<%=termId.toString() %>"/>
-						<portlet:param name="categoryId" value="<%=categoryId.toString() %>"/>
-						<portlet:param name="creatorId" value="<%=creatorId.toString() %>"/>
-						<portlet:param name="searchQuery" value="<%=searchQuery %>"/>	
-					</portlet:actionURL>
-					<li class="filter-menu"><a href="${filterByParentInstitution}"><div class="filter-menu-link">${parentInstitution.name}<span ${hasParentInstitutionFiltered ? 'class="icon-large icon-remove"' : ''}></span></div></a></li>
-				</c:forEach>
-				</ul>
-			</liferay-ui:panel>
-			<%}%>
-			
-		 	<!-- 	institution filter  -->
-			<c:if test="${hasParentInstitutionFiltered}">
-			<%if(presentInstitutions.size()>0){ %>
-			<liferay-ui:panel extended="true" title="sub-institution" cssClass='${hasInstitutionFiltered ? "filtered" : "notFiltered"}'>
-				<ul>
-				<c:forEach items="<%=presentInstitutions %>" var="institution">
-					<portlet:actionURL var="filterByInstitution" name="addFilter">
-						<portlet:param name="jspPage" value="/guest/videosList.jsp" />
-						<portlet:param name="parentInstitutionId" value="<%=parentInstitutionId.toString() %>"/>
-						<portlet:param name="institutionId" value='${hasInstitutionFiltered ? "0" : institution.institutionId}'/>
-						<portlet:param name="termId" value="<%=termId.toString() %>"/>
-						<portlet:param name="categoryId" value="<%=categoryId.toString() %>"/>
-						<portlet:param name="creatorId" value="<%=creatorId.toString() %>"/>
-						<portlet:param name="searchQuery" value="<%=searchQuery %>"/>	
-					</portlet:actionURL>
-					<li class="filter-menu"><a href="${filterByInstitution}"><div class="filter-menu-link">${institution.name}<span ${hasInstitutionFiltered ? 'class="icon-large icon-remove"' : ''}></span></div></a></li>
-				</c:forEach>
-				</ul>
-			</liferay-ui:panel>
-			<%}%>
-			</c:if>
-			
-			<!-- 	terms filter -->
-			<%if(presentTerms.size()>0){%>
-			<liferay-ui:panel extended="true" title="term" cssClass='${hasTermFiltered ? "filtered" : "notFiltered"}'>
-				<ul class="terms">
-				<c:forEach items="<%=presentTerms %>" var="term">
-					<portlet:actionURL var="filterByTerm" name="addFilter">
-						<portlet:param name="jspPage" value="/guest/videosList.jsp" />
-						<portlet:param name="institutionId" value="<%=institutionId.toString() %>"/>
-						<portlet:param name="parentInstitutionId" value="<%=parentInstitutionId.toString() %>"/>	
-						<portlet:param name="termId" value='${hasTermFiltered ? "0" : term.termId}'/>
-						<portlet:param name="categoryId" value="<%=categoryId.toString() %>"/>
-						<portlet:param name="creatorId" value="<%=creatorId.toString() %>"/>
-						<portlet:param name="searchQuery" value="<%=searchQuery %>"/>	
-					</portlet:actionURL>
-					<li class="filter-menu"><a href="${filterByTerm}"><div class="filter-menu-link">${term.termName}<span ${hasTermFiltered ? 'class="icon-large icon-remove"' : ''}></span></div></a></li>
-				</c:forEach>
-				</ul>
-				<c:if test="${hasManyTerms}">
-					<div id="loadMoreTerms">mehr...</div>
+<div class="catalogue-container">
+	<div class="row-fluid">
+	<%if(!resultSetEmpty){ %>
+		<div class="span3">
+			<liferay-ui:panel-container>
+				<!-- 	parentinstitution filter -->
+				<%if(presentParentInstitutions.size()>0){ %>
+				<liferay-ui:panel extended="true" title="institution" cssClass='${hasParentInstitutionFiltered ? "filtered" : "notFiltered"}'>
+					<ul>
+					<c:forEach items="<%=presentParentInstitutions %>" var="parentInstitution">
+						<portlet:actionURL var="filterByParentInstitution" name="addFilter">
+							<portlet:param name="jspPage" value="/guest/videosList.jsp" />
+							<portlet:param name="parentInstitutionId" value='${hasParentInstitutionFiltered ? "0" : parentInstitution.institutionId}'/>
+							<portlet:param name="institutionId" value="<%=institutionId.toString() %>"/>				
+							<portlet:param name="termId" value="<%=termId.toString() %>"/>
+							<portlet:param name="categoryId" value="<%=categoryId.toString() %>"/>
+							<portlet:param name="creatorId" value="<%=creatorId.toString() %>"/>
+							<portlet:param name="searchQuery" value="<%=searchQuery %>"/>	
+						</portlet:actionURL>
+						<li class="filter-menu"><a href="${filterByParentInstitution}"><div class="filter-menu-link">${parentInstitution.name}<span ${hasParentInstitutionFiltered ? 'class="icon-large icon-remove"' : ''}></span></div></a></li>
+					</c:forEach>
+					</ul>
+				</liferay-ui:panel>
+				<%}%>
+				
+			 	<!-- 	institution filter  -->
+				<c:if test="${hasParentInstitutionFiltered}">
+				<%if(presentInstitutions.size()>0){ %>
+				<liferay-ui:panel extended="true" title="sub-institution" cssClass='${hasInstitutionFiltered ? "filtered" : "notFiltered"}'>
+					<ul>
+					<c:forEach items="<%=presentInstitutions %>" var="institution">
+						<portlet:actionURL var="filterByInstitution" name="addFilter">
+							<portlet:param name="jspPage" value="/guest/videosList.jsp" />
+							<portlet:param name="parentInstitutionId" value="<%=parentInstitutionId.toString() %>"/>
+							<portlet:param name="institutionId" value='${hasInstitutionFiltered ? "0" : institution.institutionId}'/>
+							<portlet:param name="termId" value="<%=termId.toString() %>"/>
+							<portlet:param name="categoryId" value="<%=categoryId.toString() %>"/>
+							<portlet:param name="creatorId" value="<%=creatorId.toString() %>"/>
+							<portlet:param name="searchQuery" value="<%=searchQuery %>"/>	
+						</portlet:actionURL>
+						<li class="filter-menu"><a href="${filterByInstitution}"><div class="filter-menu-link">${institution.name}<span ${hasInstitutionFiltered ? 'class="icon-large icon-remove"' : ''}></span></div></a></li>
+					</c:forEach>
+					</ul>
+				</liferay-ui:panel>
+				<%}%>
 				</c:if>
-			</liferay-ui:panel>
-			<%}%>
-		
+				
+				<!-- 	terms filter -->
+				<%if(presentTerms.size()>0){%>
+				<liferay-ui:panel extended="true" title="term" cssClass='${hasTermFiltered ? "filtered" : "notFiltered"}'>
+					<ul class="terms">
+					<c:forEach items="<%=presentTerms %>" var="term">
+						<portlet:actionURL var="filterByTerm" name="addFilter">
+							<portlet:param name="jspPage" value="/guest/videosList.jsp" />
+							<portlet:param name="institutionId" value="<%=institutionId.toString() %>"/>
+							<portlet:param name="parentInstitutionId" value="<%=parentInstitutionId.toString() %>"/>	
+							<portlet:param name="termId" value='${hasTermFiltered ? "0" : term.termId}'/>
+							<portlet:param name="categoryId" value="<%=categoryId.toString() %>"/>
+							<portlet:param name="creatorId" value="<%=creatorId.toString() %>"/>
+							<portlet:param name="searchQuery" value="<%=searchQuery %>"/>	
+						</portlet:actionURL>
+						<li class="filter-menu"><a href="${filterByTerm}"><div class="filter-menu-link">${term.termName}<span ${hasTermFiltered ? 'class="icon-large icon-remove"' : ''}></span></div></a></li>
+					</c:forEach>
+					</ul>
+					<c:if test="${hasManyTerms}">
+						<div id="loadMoreTerms">mehr...</div>
+					</c:if>
+				</liferay-ui:panel>
+				<%}%>
 			
-			<!-- 	category filter -->
-			<%if(presentCategories.size()>0){%>
-			<liferay-ui:panel extended="true" title="category" cssClass='${hasCategoryFiltered ? "filtered" : "notFiltered"}'>
-				<ul>
-				<c:forEach items="<%=presentCategories %>" var="category">
-		    		<portlet:actionURL var="filterByCategory" name="addFilter">
-						<portlet:param name="jspPage" value="/guest/videosList.jsp" />
-						<portlet:param name="institutionId" value="<%=institutionId.toString() %>"/>
-						<portlet:param name="parentInstitutionId" value="<%=parentInstitutionId.toString() %>"/>
-						<portlet:param name="termId" value="<%=termId.toString() %>"/>
-						<portlet:param name="categoryId" value='${hasCategoryFiltered ? "0" : category.categoryId}'/>
-						<portlet:param name="creatorId" value="<%=creatorId.toString() %>"/>	
-						<portlet:param name="searchQuery" value="<%=searchQuery %>"/>	
-					</portlet:actionURL>
-					<li class="filter-menu"><a href="${filterByCategory}"><div class="filter-menu-link">${category.name} <span ${hasCategoryFiltered ? 'class="icon-large icon-remove"' : ''}></span></div></a></li>
-				</c:forEach>
-				</ul>
-			</liferay-ui:panel>
-			<%}%>
-		</liferay-ui:panel-container>
-	</div>
-<%}%>
+				
+				<!-- 	category filter -->
+				<%if(presentCategories.size()>0){%>
+				<liferay-ui:panel extended="true" title="category" cssClass='${hasCategoryFiltered ? "filtered" : "notFiltered"}'>
+					<ul>
+					<c:forEach items="<%=presentCategories %>" var="category">
+			    		<portlet:actionURL var="filterByCategory" name="addFilter">
+							<portlet:param name="jspPage" value="/guest/videosList.jsp" />
+							<portlet:param name="institutionId" value="<%=institutionId.toString() %>"/>
+							<portlet:param name="parentInstitutionId" value="<%=parentInstitutionId.toString() %>"/>
+							<portlet:param name="termId" value="<%=termId.toString() %>"/>
+							<portlet:param name="categoryId" value='${hasCategoryFiltered ? "0" : category.categoryId}'/>
+							<portlet:param name="creatorId" value="<%=creatorId.toString() %>"/>	
+							<portlet:param name="searchQuery" value="<%=searchQuery %>"/>	
+						</portlet:actionURL>
+						<li class="filter-menu"><a href="${filterByCategory}"><div class="filter-menu-link">${category.name} <span ${hasCategoryFiltered ? 'class="icon-large icon-remove"' : ''}></span></div></a></li>
+					</c:forEach>
+					</ul>
+				</liferay-ui:panel>
+				<%}%>
+			</liferay-ui:panel-container>
+		<!-- span3 -->
+		</div>
+	<%}%>
 
 <%if(!resultSetEmpty){%><div class="span9"><%}%>
 <%if(resultSetEmpty){%><div class="none"><%}%>
@@ -436,6 +437,7 @@
 								<%	
 							}
 						%>
+				<!-- videotile  -->
 				</div>
 				
 				<!-- sublist for searched videos -->
@@ -506,8 +508,11 @@
 	</liferay-ui:search-container-row>
 	<liferay-ui:search-iterator />
 </liferay-ui:search-container>
-
-</div>
+		<!-- span9 -->
+		</div>
+	<!-- row-fluid -->
+	</div>
+<!-- catalogue-container -->
 </div>
 
 <script type="text/javascript">

--- a/themes/lecture2go-theme/docroot/_diffs/css/l2go_view320.css
+++ b/themes/lecture2go-theme/docroot/_diffs/css/l2go_view320.css
@@ -178,7 +178,7 @@
 	    display: none;
 	}
 	
-	.row-fluid .span9 {
+	.catalogue-container .row-fluid .span9 {
 	    float: left;
 	    width: 100%;
 	    margin-top: 0;

--- a/themes/lecture2go-theme/docroot/_diffs/css/l2go_view480.css
+++ b/themes/lecture2go-theme/docroot/_diffs/css/l2go_view480.css
@@ -85,11 +85,11 @@
 	    visibility: hidden;
 	}
 	
-	.row-fluid .span3 {
+	.catalogue-container .row-fluid .span3 {
 	    width: 100%;
 	}
 	
-	.row-fluid .span9 {
+	.catalogue-container .row-fluid .span9 {
 	    width: 100%;
 	}
 	
@@ -126,7 +126,7 @@
 	    width: 100%;
 	}
 	
-	.row-fluid .span9 {
+	.catalogue-container .row-fluid .span9 {
 	    float: left;
 	    width: 100%;
 	}

--- a/themes/lecture2go-theme/docroot/_diffs/css/l2go_view720.css
+++ b/themes/lecture2go-theme/docroot/_diffs/css/l2go_view720.css
@@ -3,15 +3,15 @@
 		display:none;
 	}
 	
-	.aui .row-fluid .span9 {
+	.catalogue-container .row-fluid .span9 {
 	    width: 74%;
 	}
 	
-	.aui .row-fluid .span3 {
+	.catalogue-container .row-fluid .span3 {
 	    width: 25%;
 	}	
 	
-	.aui .row-fluid [class*="span"] {
+	.catalogue-container .row-fluid [class*="span"] {
 	    margin-left: 1%;
 	}
 	
@@ -95,7 +95,7 @@
 	    margin-top: -50px;
 	}
 
-	.row-fluid .span3 {
+	.catalogue-container .row-fluid .span3 {
 	    margin: 0px;
 	    padding: 0px;
 	    float: left;
@@ -118,7 +118,7 @@
 	    visibility: hidden;
 	}
 	
-	.row-fluid .span9 {
+	.catalogue-container .row-fluid .span9 {
 	    float: left;
 	}
 	

--- a/themes/lecture2go-theme/docroot/_diffs/css/l2go_view960.css
+++ b/themes/lecture2go-theme/docroot/_diffs/css/l2go_view960.css
@@ -3,7 +3,7 @@
 	    background: rgba(0, 0, 0, 0) url("/lecture2go-theme/images/logo_l2go.png") no-repeat scroll right -3px top -8px / 159px auto;
 	}
 
-	.aui .row-fluid::before, .aui .row-fluid::after {
+	.catalogue-container .row-fluid::before, .aui .row-fluid::after {
 	    margin-top: 30px;
 	}
 	
@@ -45,7 +45,7 @@
 	    float: right;
 	    height: 24px;
 	    margin-right: -313px;
-	    margin-top: -28px;
+	    margin-top: 3px;
 	}
 	
 	.aui .container-fluid::before, .aui .container-fluid::after {
@@ -59,7 +59,7 @@
 	#_lgopenaccessvideos_WAR_lecture2goportlet_searchQuery {
 	    float: right;
 	    height: 19px;
-	    margin: -30px 0 2px;
+	    margin: 0 0 2px;
 	    padding: 4px 0 4px 4px;
 	    width: 309px;
 	}
@@ -81,15 +81,15 @@
     	padding: 0;
 	}
 
-	.aui .row-fluid .span9 {
+	.catalogue-container .row-fluid .span9 {
 	    width: 74%;
 	}
 	
-	.aui .row-fluid .span3 {
+	.catalogue-container .row-fluid .span3 {
 	    width: 25%;
 	}	
 	
-	.aui .row-fluid [class*="span"] {
+	.catalogue-container .row-fluid [class*="span"] {
 	    margin-left: 1%;
 	}
 	


### PR DESCRIPTION
Bootstrap-span (e.g. span3, span9) css styles are now bound to a
container (added on catalogue page), so default span behaviour can be
used in other contexts (preparation for front page)