### PR TITLE
Wrong pre-selected video in lecture series

### DIFF
--- a/portlets/lecture2go-portlet/docroot/WEB-INF/src/de/uhh/l2g/plugins/guest/OpenAccessVideos.java
+++ b/portlets/lecture2go-portlet/docroot/WEB-INF/src/de/uhh/l2g/plugins/guest/OpenAccessVideos.java
@@ -170,7 +170,7 @@ public class OpenAccessVideos extends MVCPortlet {
 	    	try{
 	    		lectureseries = LectureseriesLocalServiceUtil.getLectureseries(objectId);
 	    		if(!secLink){
-	    			video = VideoLocalServiceUtil.getFullVideo(lectureseries.getLatestOpenAccessVideoId());
+	    			video = VideoLocalServiceUtil.getFullVideo(lectureseries.getPreviewVideoId());
 	    		}else{
 	    			Long videoId = VideoLocalServiceUtil.getLatestClosedAccessVideoId(objectId);
 	    			video = VideoLocalServiceUtil.getFullVideo(videoId);


### PR DESCRIPTION
The preselected video of a lectureseries had ignored the sort order of
the lectureseries.